### PR TITLE
Remove landscape failures

### DIFF
--- a/pynocchio/bookmark_database_manager.py
+++ b/pynocchio/bookmark_database_manager.py
@@ -42,7 +42,7 @@ class BookmarkManager(BookmarkBaseModel):
             q = table.insert(comic_name=name, comic_path=path,
                              comic_page=page, page_data=data)
             q.execute()
-            logger.info('%s item inserted.' % table.__class__)
+            logger.info('%s item inserted.', table.__class__)
         except peewee.IntegrityError:
             q = table.update(comic_page=page, page_data=data).where(
                 table.comic_path == path)

--- a/pynocchio/comic.py
+++ b/pynocchio/comic.py
@@ -2,7 +2,7 @@
 import os
 
 
-class Comic:
+class Comic():
     """This is basic class of Pynocchio. Represents a comic object"""
 
     def __init__(self, name, path):
@@ -34,7 +34,7 @@ class Comic:
         self._path = value
 
 
-class Page:
+class Page():
     """This is basic class of Pynocchio. Represents a comic page object"""
 
     def __init__(self, data, title, number):

--- a/pynocchio/comic_file_loader.py
+++ b/pynocchio/comic_file_loader.py
@@ -14,7 +14,7 @@ class ComicLoader(QtCore.QObject):
     done = QtCore.pyqtSignal()
 
     def __init__(self):
-        super(ComicLoader, self).__init__()
+        super().__init__()
         self.data = []
 
     def load(self, filename):

--- a/pynocchio/comic_file_loader_factory.py
+++ b/pynocchio/comic_file_loader_factory.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-class ComicLoaderFactory:
+class ComicLoaderFactory():
 
     @staticmethod
     def create_loader(filename):

--- a/pynocchio/comic_file_loader_image.py
+++ b/pynocchio/comic_file_loader_image.py
@@ -16,7 +16,7 @@ logger.setLevel(logging.INFO)
 class ComicImageLoader(ComicLoader):
 
     def __init__(self):
-        super(ComicImageLoader, self).__init__()
+        super().__init__()
 
     def load(self, filename):
         """ Load image file and create Page objects with them.
@@ -26,7 +26,7 @@ class ComicImageLoader(ComicLoader):
         """
 
         # get files with extension stored in ext
-        logger.info('Loading from %s' % filename)
+        logger.info('Loading from %s', filename)
 
         file_list = []
 
@@ -43,10 +43,10 @@ class ComicImageLoader(ComicLoader):
         self.data = []
 
         for idx, name in enumerate(file_list):
-            logger.info('Trying to load %s' % name)
+            logger.info('Trying to load %s', name)
 
             if get_file_extension(name).lower() in IMAGE_FILE_FORMATS:
-                logger.info('Adding page %s' % name)
+                logger.info('Adding page %s', name)
 
                 with open(join_path('', dir_name, name), 'rb') as img:
                     self.data.append(Page(img.read(), name, page))

--- a/pynocchio/comic_file_loader_rar.py
+++ b/pynocchio/comic_file_loader_rar.py
@@ -28,7 +28,7 @@ def is_rarfile(filename):
 class ComicRarLoader(ComicLoader):
 
     def __init__(self):
-        super(ComicRarLoader, self).__init__()
+        super().__init__()
 
     def load(self, filename):
         """ Load zip file and create Page objects whit them.
@@ -52,11 +52,10 @@ class ComicRarLoader(ComicLoader):
                         self.data.append(Page(rar.read(name), name, page))
                         page += 1
                     except rarfile.BadRarFile as exc:
-                        logger.exception('Error reading %s file. %s' % (name,
-                                                                        exc))
+                        logger.exception('Error reading %s file. %s', name, exc)
 
                 self.progress.emit(idx * aux)
-            logger.info('Successfully loaded %s' % filename)
+            logger.info('Successfully loaded %s', filename)
 
         if not self.data:
             error_text = 'File not loaded!'

--- a/pynocchio/comic_file_loader_rar.py
+++ b/pynocchio/comic_file_loader_rar.py
@@ -52,7 +52,11 @@ class ComicRarLoader(ComicLoader):
                         self.data.append(Page(rar.read(name), name, page))
                         page += 1
                     except rarfile.BadRarFile as exc:
-                        logger.exception('Error reading %s file. %s', name, exc)
+                        logger.exception(
+                            'Error reading %s file. %s',
+                            name,
+                            exc
+                        )
 
                 self.progress.emit(idx * aux)
             logger.info('Successfully loaded %s', filename)

--- a/pynocchio/comic_file_loader_tar.py
+++ b/pynocchio/comic_file_loader_tar.py
@@ -80,9 +80,17 @@ class ComicTarLoader(ComicLoader):
                         self.data.append(Page(data, name, page))
                         page += 1
                     except tarfile.ExtractError as exc:
-                        logger.exception('Error in extract %s file. %s', name, exc)
+                        logger.exception(
+                            'Error in extract %s file. %s',
+                            name,
+                            exc
+                        )
                     except tarfile.ReadError as exc:
-                        logger.exception('Error in read %s file. %s', name, exc)
+                        logger.exception(
+                            'Error in read %s file. %s',
+                            name,
+                            exc
+                        )
 
                 self.progress.emit(idx * aux)
 

--- a/pynocchio/comic_file_loader_tar.py
+++ b/pynocchio/comic_file_loader_tar.py
@@ -51,7 +51,7 @@ class TarFile(tarfile.TarFile):
 class ComicTarLoader(ComicLoader):
 
     def __init__(self):
-        super(ComicTarLoader, self).__init__()
+        super().__init__()
 
     def load(self, filename):
         """ Load zip file and create Page objects whit them.
@@ -60,7 +60,7 @@ class ComicTarLoader(ComicLoader):
                 filename: name of compact zip file
         """
 
-        logger.info('Trying to load %s' % filename)
+        logger.info('Trying to load %s', filename)
 
         with TarFile(filename, 'r') as tar:
 
@@ -71,20 +71,18 @@ class ComicTarLoader(ComicLoader):
             self.data = []
 
             for idx, name in enumerate(name_list):
-                logger.info('Trying to load %s' % name)
+                logger.info('Trying to load %s', name)
 
                 if get_file_extension(name).lower() in IMAGE_FILE_FORMATS:
-                    logger.info('Adding page %s' % name)
+                    logger.info('Adding page %s', name)
                     try:
                         data = tar.read(name)
                         self.data.append(Page(data, name, page))
                         page += 1
                     except tarfile.ExtractError as exc:
-                        logger.exception('Error in extract %s file. %s' %
-                                         (name, exc))
+                        logger.exception('Error in extract %s file. %s', name, exc)
                     except tarfile.ReadError as exc:
-                        logger.exception('Error in read %s file. %s' % (name,
-                                                                        exc))
+                        logger.exception('Error in read %s file. %s', name, exc)
 
                 self.progress.emit(idx * aux)
 

--- a/pynocchio/comic_file_loader_zip.py
+++ b/pynocchio/comic_file_loader_zip.py
@@ -30,7 +30,7 @@ class ComicZipLoader(ComicLoader):
     """
 
     def __init__(self):
-        super(ComicZipLoader, self).__init__()
+        super().__init__()
 
     def load(self, filename):
         """ Load zip file and create Page objects whit them.
@@ -42,7 +42,7 @@ class ComicZipLoader(ComicLoader):
             NoDataFindException: if not data loaded from zip file
         """
 
-        logger.info('Trying to load %s' % filename)
+        logger.info('Trying to load %s', filename)
 
         with zipfile.ZipFile(filename, 'r') as zf:
 
@@ -53,16 +53,15 @@ class ComicZipLoader(ComicLoader):
             self.data = []
 
             for idx, name in enumerate(name_list):
-                logger.info('Trying to load %s' % name)
+                logger.info('Trying to load %s', name)
 
                 if get_file_extension(name).lower() in IMAGE_FILE_FORMATS:
-                    logger.info('Adding page %s' % name)
+                    logger.info('Adding page %s', name)
                     try:
                         self.data.append(Page(zf.read(name), name, page))
                         page += 1
                     except zipfile.BadZipfile as exc:
-                        logger.exception('Error in read %s file. %s' % (name,
-                                                                        exc))
+                        logger.exception('Error in read %s file. %s', name, exc)
 
                 self.progress.emit(idx * aux)
 

--- a/pynocchio/comic_file_loader_zip.py
+++ b/pynocchio/comic_file_loader_zip.py
@@ -61,7 +61,11 @@ class ComicZipLoader(ComicLoader):
                         self.data.append(Page(zf.read(name), name, page))
                         page += 1
                     except zipfile.BadZipfile as exc:
-                        logger.exception('Error in read %s file. %s', name, exc)
+                        logger.exception(
+                            'Error in read %s file. %s',
+                            name,
+                            exc
+                        )
 
                 self.progress.emit(idx * aux)
 

--- a/pynocchio/comic_page_handler.py
+++ b/pynocchio/comic_page_handler.py
@@ -3,7 +3,7 @@
 from PyQt5 import QtGui
 
 
-class ComicPageHandler:
+class ComicPageHandler():
 
     def __init__(self, comic, index=0):
         self.comic = comic
@@ -62,8 +62,7 @@ class ComicPageHandlerSinglePage(ComicPageHandler):
 class ComicPageHandlerDoublePage(ComicPageHandler):
 
     def __init__(self, comic, inverse=False, index=0):
-        super(ComicPageHandlerDoublePage, self).__init__(comic=comic,
-                                                         index=index)
+        super().__init__(comic=comic, index=index)
         self.inverse = inverse
 
     def go_next_page(self):

--- a/pynocchio/comic_page_handler_factory.py
+++ b/pynocchio/comic_page_handler_factory.py
@@ -4,7 +4,7 @@ from .comic_page_handler import ComicPageHandlerSinglePage
 from .comic_page_handler import ComicPageHandlerDoublePage
 
 
-class ComicPageHandlerFactory:
+class ComicPageHandlerFactory():
     read_mode = {
         False: ComicPageHandlerSinglePage,
         True: ComicPageHandlerDoublePage,

--- a/pynocchio/comic_path_filter.py
+++ b/pynocchio/comic_path_filter.py
@@ -5,7 +5,7 @@ from .utility import join_path
 from .exception import NoDataFindException
 
 
-class ComicPathFilter:
+class ComicPathFilter():
 
     def __init__(self, extension_list):
         self.file_list = []
@@ -29,14 +29,16 @@ class ComicPathFilter:
             return self.file_list[0] == filename
         except IndexError as exc:
             raise NoDataFindException(
-                'ComicPathFilter file list is empty!') from exc
+                'ComicPathFilter file list is empty!'
+            ) from exc
 
     def is_last_comic(self, filename):
         try:
             return self.file_list[-1] == filename
         except IndexError as exc:
             raise NoDataFindException(
-                'ComicPathFilter file list is empty!') from exc
+                'ComicPathFilter file list is empty!'
+            ) from exc
 
     def get_previous_comic(self, filename):
 

--- a/pynocchio/exception.py
+++ b/pynocchio/exception.py
@@ -4,7 +4,7 @@
 class PynocchioBaseException(Exception):
 
     def __init__(self, msg, *args):
-        super(PynocchioBaseException, self).__init__(msg, *args)
+        super().__init__(msg, *args)
         self.message = msg.format(args)
 
     def __str__(self):

--- a/pynocchio/go_to_page_dialog.py
+++ b/pynocchio/go_to_page_dialog.py
@@ -8,7 +8,7 @@ from .comic_page_handler_factory import ComicPageHandlerFactory
 
 class GoToDialog(QtWidgets.QDialog):
     def __init__(self, comic_handler, parent=None):
-        super(GoToDialog, self).__init__(parent=parent)
+        super().__init__(parent=parent)
 
         self.ui = go_to_page_dialog_ui.Ui_GoPageDialog()
         self.ui.setupUi(self)

--- a/pynocchio/main_window_model.py
+++ b/pynocchio/main_window_model.py
@@ -28,7 +28,7 @@ class MainWindowModel(QtCore.QObject):
     load_done = QtCore.pyqtSignal()
 
     def __init__(self):
-        super(MainWindowModel, self).__init__()
+        super().__init__()
         self.comic = None
         self.comic_page_handler = None
         self.settings_manager = SettingsManager()
@@ -56,7 +56,7 @@ class MainWindowModel(QtCore.QObject):
         return self.settings_manager.load_current_directory()
 
     def load(self, filename, initial_page=0):
-        logger.info('Loading %s at %i' % (filename, initial_page))
+        logger.info('Loading %s at %i', filename, initial_page)
 
         loader = ComicLoaderFactory.create_loader(filename)
         loader.progress.connect(self.load_progressbar_value)
@@ -65,7 +65,7 @@ class MainWindowModel(QtCore.QObject):
             loader.load(filename)
         except NoDataFindException as exc:
             from pynocchio.comic import Page
-            logger.exception('Error in load comic! %s' % exc)
+            logger.exception('Error in load comic! %s', exc)
             q_file = QtCore.QFile(":/icons/notCover.png")
             q_file.open(QtCore.QIODevice.ReadOnly)
             loader.data.append(Page(q_file.readAll(), 'exit_red_1.png', 0))

--- a/pynocchio/main_window_view.py
+++ b/pynocchio/main_window_view.py
@@ -25,7 +25,7 @@ class MainWindowView(QtWidgets.QMainWindow):
     MAX_BOOKMARK_FILES = 5
 
     def __init__(self, model, parent=None):
-        super(MainWindowView, self).__init__(parent=parent)
+        super().__init__(parent=parent)
         self.model = model
 
         self.ui = main_window_view_ui.Ui_MainWindowView()
@@ -362,7 +362,7 @@ class MainWindowView(QtWidgets.QMainWindow):
 
     def open_comics(self, filename, initial_page=0):
         if filename:
-            logger.info('Opening comic %s' % filename)
+            logger.info('Opening comic %s', filename)
 
             try:
 

--- a/pynocchio/not_found_dialog.py
+++ b/pynocchio/not_found_dialog.py
@@ -7,6 +7,6 @@ from .uic_files import not_found_dialog_ui
 class NotFoundDialog(QtWidgets.QDialog):
 
     def __init__(self, parent=None):
-        super(NotFoundDialog, self).__init__(parent=parent)
+        super().__init__(parent=parent)
         self.ui = not_found_dialog_ui.Ui_NotFoundDialog()
         self.ui.setupUi(self)

--- a/pynocchio/preference_dialog.py
+++ b/pynocchio/preference_dialog.py
@@ -8,7 +8,7 @@ from .uic_files import preference_dialog_ui
 class PreferenceDialog(QtWidgets.QDialog):
 
     def __init__(self, preference, parent=None):
-        super(PreferenceDialog, self).__init__(parent=parent)
+        super().__init__(parent=parent)
 
         self.ui = preference_dialog_ui.Ui_config_dialog()
         self.ui.setupUi(self)

--- a/pynocchio/pynocchio.py
+++ b/pynocchio/pynocchio.py
@@ -27,7 +27,7 @@ QFile = QtCore.QFile
 class Pynocchio(QtWidgets.QApplication):
 
     def __init__(self):
-        super(Pynocchio, self).__init__(sys.argv)
+        super().__init__(sys.argv)
         self.setOrganizationName('Pynocchio')
         self.setApplicationName('Pynocchio')
 

--- a/pynocchio/pynocchio.py
+++ b/pynocchio/pynocchio.py
@@ -32,7 +32,7 @@ class Pynocchio(QtWidgets.QApplication):
         self.setApplicationName('Pynocchio')
 
         self.setStyle('Fusion')
-        self.setStyleSheet(qdarkgraystyle.load_stylesheet_pyqt5())
+        self.setStyleSheet(qdarkgraystyle.load_stylesheet())
 
         if hasattr(self, 'setApplicationDisplayName'):
             self.setApplicationDisplayName('Pynocchio')

--- a/pynocchio/settings_manager.py
+++ b/pynocchio/settings_manager.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-class SettingsManager:
+class SettingsManager():
 
     def __init__(self):
         self.settings = QtCore.QSettings('Pynocchio', 'Pynocchio')
@@ -38,7 +38,7 @@ class SettingsManager:
         return recent_files_list
 
     def save_view_adjust(self, object_name):
-        logger.info('Saving view adjust: %s' % object_name)
+        logger.info('Saving view adjust: %s', object_name)
         self.settings.setValue('view_adjust', object_name)
 
     def load_view_adjust(self, default_object_name):
@@ -46,7 +46,7 @@ class SettingsManager:
         return self.settings.value('view_adjust', default_object_name)
 
     def save_current_directory(self, current_directory):
-        logger.info('Saving current directory %s' % current_directory)
+        logger.info('Saving current directory %s', current_directory)
         self.settings.setValue('current_directory', current_directory)
 
     def load_current_directory(self):


### PR DESCRIPTION
PR for removing some of the code health failures from Landscape:
- use new-style classes
- specify string format arguments as logging function parameters
- remove deprecated `load_stylesheet_pyqt5` and replace with `load_stylesheet`