### PR TITLE
Fix missing bounds check in goPreviousPage

### DIFF
--- a/src/models/comic_handler_single_page.py
+++ b/src/models/comic_handler_single_page.py
@@ -18,7 +18,8 @@ class ComicHandlerSinglePage(ComicHandler):
         """
         Go to the previous page.
         """
-        self.setCurrentPageIndex(self._currentPageIndex - 1)
+        if self._currentPageIndex > 0:
+            self.setCurrentPageIndex(self._currentPageIndex - 1)
 
     def getCurrentPageImage(self) -> QPixmap:
         """


### PR DESCRIPTION
## Description

This PR fixes a bug in the `goPreviousPage` method of `ComicHandlerSinglePage` class where the page index was decremented without checking if it goes below zero.

## Changes

- Added a bounds check in `goPreviousPage` method to ensure the page index doesn't go below zero
- The method now only decrements the page index if `self._currentPageIndex > 0`

## Testing

The fix ensures that when on the first page (index 0), calling `goPreviousPage` will not attempt to navigate to a negative index, preventing potential IndexError or unexpected behavior.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.